### PR TITLE
GeometryView default init

### DIFF
--- a/Gem/Code/Source/Render/RenderJoyBillboardPass.h
+++ b/Gem/Code/Source/Render/RenderJoyBillboardPass.h
@@ -81,7 +81,7 @@ namespace RenderJoy
         AZ::RPI::PipelineStateForDraw m_pipelineStateForDraw;
     
         // The draw item submitted by this pass
-        AZ::RHI::GeometryView m_geometryView;
+        AZ::RHI::GeometryView m_geometryView{ AZ::RHI::MultiDevice::AllDevices };
         AZ::RHI::DrawItem m_item;
     
         // The stencil reference value for the draw item

--- a/Gem/Code/Source/Render/RenderJoyShaderPass.h
+++ b/Gem/Code/Source/Render/RenderJoyShaderPass.h
@@ -74,7 +74,7 @@ namespace RenderJoy
         AZ::Data::Instance<AZ::RPI::Shader> m_shader;
 
         // The draw item submitted by this pass
-        AZ::RHI::GeometryView m_geometryView;
+        AZ::RHI::GeometryView m_geometryView{ AZ::RHI::MultiDevice::AllDevices };
         AZ::RHI::DrawItem m_item;
 
         // The stencil reference value for the draw item


### PR DESCRIPTION
You need to now give the geometry view a default initializer, without it RenderJoy cannot compile on the newest version of O3DE.